### PR TITLE
Add templated homepage and gallery

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,11 @@
 # Memories of Wedding
 
 Bu basit uygulama, düğüne katılan misafirlerin çektikleri fotoğrafları kolayca
-size iletebilmesi için hazırlanmıştır. Misafirler QR kodu taradıklarında fotoğraf
-yükleme sayfasına yönlendirilir ve cihazlarındaki fotoğrafları "Yükle" butonu
-ile paylaşabilirler.
+size iletebilmesi için hazırlanmıştır. Artık ana sayfada karşılayıcı bir mesaj,
+fotoğraf yükleme formu ve yüklenen fotoğrafları görebileceğiniz bir galeri
+bulunmaktadır. Misafirler QR kodu taradıklarında fotoğraf yükleme sayfasına
+veya doğrudan ana sayfaya yönlendirilerek cihazlarındaki fotoğrafları "Yükle"
+butonu ile paylaşabilirler.
 
 ## Kurulum
 
@@ -20,9 +22,11 @@ pip install -r requirements.txt
 python app.py
 ```
 
-Uygulama 5000 portunda çalışacaktır. QR kodunuzu `http://<sunucu_adresi>:5000/upload`
-adresine yönlendirebilirsiniz. Örneğin, kendi bilgisayarınızda test etmek için
-`http://localhost:5000/upload` adresini kullanabilirsiniz.
+Uygulama 5000 portunda çalışacaktır. Ana sayfa `http://<sunucu_adresi>:5000/`
+adresinde, fotoğraf yükleme formu `http://<sunucu_adresi>:5000/upload` ve
+galeri `http://<sunucu_adresi>:5000/gallery` adresinde yer alır. Örneğin, kendi
+bilgisayarınızda test etmek için `http://localhost:5000/` adresini
+kullanabilirsiniz.
 
 ## QR Kod Oluşturma
 
@@ -33,5 +37,6 @@ belirtebilirsiniz.
 ## Dosyalar
 
 - `app.py`: Fotoğraf yükleme servisini çalıştıran Flask uygulaması.
+- `templates/`: HTML şablonları.
 - `requirements.txt`: Gerekli Python paketleri.
 - `uploads/`: Yüklenen fotoğrafların kaydedildiği klasör.

--- a/templates/base.html
+++ b/templates/base.html
@@ -1,0 +1,26 @@
+<!doctype html>
+<html lang="tr">
+<head>
+  <meta charset="utf-8">
+  <title>{{ title or 'Memories of Wedding' }}</title>
+  <style>
+    body { font-family: Arial, sans-serif; max-width: 600px; margin: 40px auto; text-align: center; background-color: #f8f8f8; }
+    a { color: #0066cc; text-decoration: none; margin: 0 5px; }
+    header { margin-bottom: 20px; }
+    img { max-width: 100%; height: auto; }
+    input[type="file"] { margin: 20px 0; }
+    input[type="submit"], button { padding: 8px 16px; }
+  </style>
+</head>
+<body>
+  <header>
+    <h1>{{ title or 'Memories of Wedding' }}</h1>
+    <nav>
+      <a href="{{ url_for('index') }}">Ana Sayfa</a>
+      <a href="{{ url_for('upload_file') }}">Yükle</a>
+      <a href="{{ url_for('gallery') }}">Galeri</a>
+    </nav>
+  </header>
+  {% block content %}{% endblock %}
+</body>
+</html>

--- a/templates/gallery.html
+++ b/templates/gallery.html
@@ -1,0 +1,10 @@
+{% extends 'base.html' %}
+{% block content %}
+{% if images %}
+  {% for image in images %}
+    <div><img src="{{ url_for('uploaded_file', filename=image) }}" alt="{{ image }}"></div>
+  {% endfor %}
+{% else %}
+  <p>Henüz yüklenmiş fotoğraf yok.</p>
+{% endif %}
+{% endblock %}

--- a/templates/index.html
+++ b/templates/index.html
@@ -1,0 +1,5 @@
+{% extends 'base.html' %}
+{% block content %}
+<p>Hoş geldiniz! Düğün fotoğraflarınızı bizimle paylaşın.</p>
+<p><a href="{{ url_for('upload_file') }}">Fotoğraf Yükle</a> veya <a href="{{ url_for('gallery') }}">Galeriye bak</a>.</p>
+{% endblock %}

--- a/templates/success.html
+++ b/templates/success.html
@@ -1,0 +1,5 @@
+{% extends 'base.html' %}
+{% block content %}
+<p>Fotoğraf yüklendi!</p>
+<p><a href="{{ url_for('upload_file') }}">Başka fotoğraf yükle</a> veya <a href="{{ url_for('gallery') }}">Galeriye bak</a>.</p>
+{% endblock %}

--- a/templates/upload.html
+++ b/templates/upload.html
@@ -1,0 +1,7 @@
+{% extends 'base.html' %}
+{% block content %}
+<form method="post" enctype="multipart/form-data">
+  <input type="file" name="file" accept="image/*" required>
+  <input type="submit" value="Yükle">
+</form>
+{% endblock %}


### PR DESCRIPTION
## Summary
- replace inline HTML with Jinja templates and add index and gallery pages
- serve uploaded photos and document new routes in README

## Testing
- `python -m py_compile app.py`
- `python app.py`

------
https://chatgpt.com/codex/tasks/task_e_688fdd59df18833385eb31aeef6005b3