### PR TITLE
Fix 404 on Vercel by routing traffic to Flask app

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,4 @@
+{
+  "builds": [{ "src": "app.py", "use": "@vercel/python" }],
+  "routes": [{ "src": "/(.*)", "dest": "app.py" }]
+}


### PR DESCRIPTION
## Summary
- configure Vercel to route all paths to the Flask `app.py`

## Testing
- `pip install -r requirements.txt`
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_688fe83f015083339b613026854e268e