### PR TITLE
Use temporary upload directory in Flask app

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,4 +39,4 @@ belirtebilirsiniz.
 - `app.py`: Fotoğraf yükleme servisini çalıştıran Flask uygulaması.
 - `templates/`: HTML şablonları.
 - `requirements.txt`: Gerekli Python paketleri.
-- `uploads/`: Yüklenen fotoğrafların kaydedildiği klasör.
+- `/tmp/uploads`: Yüklenen fotoğrafların kaydedildiği geçici klasör.

--- a/app.py
+++ b/app.py
@@ -8,8 +8,9 @@ from flask import (
 )
 from werkzeug.utils import secure_filename
 import os
+import tempfile
 
-UPLOAD_FOLDER = 'uploads'
+UPLOAD_FOLDER = os.path.join(tempfile.gettempdir(), 'uploads')
 ALLOWED_EXTENSIONS = {'png', 'jpg', 'jpeg', 'gif'}
 
 app = Flask(__name__)


### PR DESCRIPTION
## Summary
- Store uploaded files in a temporary directory to avoid read-only filesystem issues on Vercel.
- Document new `/tmp/uploads` storage path.

## Testing
- `python -m py_compile app.py`
- `python - <<'PY'
import os
from app import app
print('UPLOAD_FOLDER:', app.config['UPLOAD_FOLDER'])
print('Exists:', os.path.exists(app.config['UPLOAD_FOLDER']))
with app.test_client() as client:
    resp = client.get('/')
    print('/', resp.status_code)
    resp2 = client.get('/gallery')
    print('/gallery', resp2.status_code)
PY`


------
https://chatgpt.com/codex/tasks/task_e_688feab46d88833382cc9bfd767b88c3