### PR TITLE
Add daisy-themed background and colors

### DIFF
--- a/static/daisy.svg
+++ b/static/daisy.svg
@@ -1,0 +1,13 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="40" height="40" viewBox="0 0 40 40">
+  <circle cx="20" cy="20" r="5" fill="#FFEB3B"/>
+  <g fill="#FFFFFF">
+    <ellipse cx="20" cy="8" rx="3" ry="8"/>
+    <ellipse cx="20" cy="32" rx="3" ry="8"/>
+    <ellipse cx="8" cy="20" rx="8" ry="3"/>
+    <ellipse cx="32" cy="20" rx="8" ry="3"/>
+    <ellipse cx="12.9" cy="12.9" rx="3" ry="8" transform="rotate(-45 12.9 12.9)"/>
+    <ellipse cx="27.1" cy="27.1" rx="3" ry="8" transform="rotate(-45 27.1 27.1)"/>
+    <ellipse cx="12.9" cy="27.1" rx="8" ry="3" transform="rotate(-45 12.9 27.1)"/>
+    <ellipse cx="27.1" cy="12.9" rx="8" ry="3" transform="rotate(-45 27.1 12.9)"/>
+  </g>
+</svg>

--- a/static/styles.css
+++ b/static/styles.css
@@ -1,12 +1,15 @@
 :root {
-  --primary-color: #6a1b9a;
-  --secondary-color: #f3e5f5;
+  --primary-color: #4caf50;
+  --secondary-color: #fffde7;
   --text-color: #333;
 }
 
 body {
   font-family: 'Poppins', sans-serif;
-  background: var(--secondary-color);
+  background-color: var(--secondary-color);
+  background-image: url('daisy.svg');
+  background-size: 80px 80px;
+  background-repeat: repeat;
   margin: 0;
   color: var(--text-color);
 }


### PR DESCRIPTION
## Summary
- use a repeating daisy SVG to decorate the page background
- switch primary/secondary colors to match a daisy theme

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689061ce58ec833381e32c13db40cc02