### PR TITLE
Add Firebase storage support for photo uploads

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,20 @@ pip install -r requirements.txt
 python app.py
 ```
 
+### Firebase ile Kullanım
+
+Fotoğrafları [Firebase Storage](https://firebase.google.com/docs/storage) üzerinde
+saklamak için aşağıdaki ortam değişkenlerini tanımlayın:
+
+```bash
+export FIREBASE_BUCKET="gs://memoriesofwedding.firebasestorage.app"  # veya kendi bucket adınız
+export GOOGLE_APPLICATION_CREDENTIALS="/path/to/serviceAccountKey.json"
+```
+
+Bu değişkenler ayarlandığında yüklenen fotoğraflar belirtilen Firebase
+bucket'ına kaydedilir ve galeri sayfasında oradan listelenir. Değişkenler
+tanımlanmazsa dosyalar yerel geçici klasörde saklanır.
+
 Uygulama 5000 portunda çalışacaktır. Ana sayfa `http://<sunucu_adresi>:5000/`
 adresinde, fotoğraf yükleme formu `http://<sunucu_adresi>:5000/upload` ve
 galeri `http://<sunucu_adresi>:5000/gallery` adresinde yer alır. Örneğin, kendi
@@ -39,4 +53,4 @@ belirtebilirsiniz.
 - `app.py`: Fotoğraf yükleme servisini çalıştıran Flask uygulaması.
 - `templates/`: HTML şablonları.
 - `requirements.txt`: Gerekli Python paketleri.
-- `/tmp/uploads`: Yüklenen fotoğrafların kaydedildiği geçici klasör.
+- `/tmp/uploads`: Firebase kullanılmadığında yüklenen fotoğrafların kaydedildiği geçici klasör.

--- a/app.py
+++ b/app.py
@@ -9,6 +9,8 @@ from flask import (
 from werkzeug.utils import secure_filename
 import os
 import tempfile
+import firebase_admin
+from firebase_admin import credentials, storage as fb_storage
 
 UPLOAD_FOLDER = os.path.join(tempfile.gettempdir(), 'uploads')
 ALLOWED_EXTENSIONS = {'png', 'jpg', 'jpeg', 'gif'}
@@ -17,6 +19,20 @@ app = Flask(__name__)
 app.config['UPLOAD_FOLDER'] = UPLOAD_FOLDER
 
 os.makedirs(UPLOAD_FOLDER, exist_ok=True)
+
+FIREBASE_BUCKET = os.environ.get("FIREBASE_BUCKET")
+firebase_bucket = None
+if FIREBASE_BUCKET:
+    cred_path = os.environ.get("GOOGLE_APPLICATION_CREDENTIALS")
+    try:
+        if cred_path and os.path.exists(cred_path):
+            cred = credentials.Certificate(cred_path)
+            firebase_admin.initialize_app(cred, {"storageBucket": FIREBASE_BUCKET})
+        else:
+            firebase_admin.initialize_app(options={"storageBucket": FIREBASE_BUCKET})
+        firebase_bucket = fb_storage.bucket()
+    except Exception:
+        firebase_bucket = None
 
 def allowed_file(filename):
     return '.' in filename and filename.rsplit('.', 1)[1].lower() in ALLOWED_EXTENSIONS
@@ -37,6 +53,13 @@ def upload_file():
             filename = secure_filename(file.filename)
             path = os.path.join(app.config['UPLOAD_FOLDER'], filename)
             file.save(path)
+            if firebase_bucket:
+                blob = firebase_bucket.blob(filename)
+                blob.upload_from_filename(path)
+                try:
+                    blob.make_public()
+                except Exception:
+                    pass
             return render_template('success.html')
         else:
             return 'Geçersiz dosya türü', 400
@@ -50,8 +73,13 @@ def uploaded_file(filename):
 
 @app.route('/gallery')
 def gallery():
-    images = [f for f in os.listdir(app.config['UPLOAD_FOLDER']) if allowed_file(f)]
-    return render_template('gallery.html', images=images)
+    if firebase_bucket:
+        blobs = firebase_bucket.list_blobs()
+        images = [blob.public_url for blob in blobs if allowed_file(blob.name)]
+        return render_template('gallery.html', images=images, hosted=True)
+    else:
+        images = [f for f in os.listdir(app.config['UPLOAD_FOLDER']) if allowed_file(f)]
+        return render_template('gallery.html', images=images, hosted=False)
 
 if __name__ == '__main__':
     app.run(host='0.0.0.0', port=5000)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 Flask==2.3.2
 Werkzeug==2.3.4
+firebase-admin==6.2.0

--- a/templates/gallery.html
+++ b/templates/gallery.html
@@ -3,7 +3,7 @@
 {% if images %}
 <div class="gallery-grid">
   {% for image in images %}
-    <div><img src="{{ url_for('uploaded_file', filename=image) }}" alt="{{ image }}"></div>
+    <div><img src="{{ image if hosted else url_for('uploaded_file', filename=image) }}" alt="uploaded image"></div>
   {% endfor %}
 </div>
 {% else %}


### PR DESCRIPTION
## Summary
- integrate optional Firebase Storage to persist uploads and list them in the gallery
- allow gallery template to display remote Firebase URLs
- document Firebase setup and add firebase-admin dependency

## Testing
- `python -m py_compile app.py`
- `python app.py >/tmp/server.log 2>&1 & PID=$!; sleep 2; kill $PID; sleep 1; cat /tmp/server.log`


------
https://chatgpt.com/codex/tasks/task_e_68ab1e7b3fd88333b585d69b81a461e0