### PR TITLE
Add local storage fallback for uploads

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 __pycache__/
 uploads/
+static/uploads/
 *-firebase-adminsdk-*.json

--- a/README.md
+++ b/README.md
@@ -33,6 +33,8 @@ kullanabilirsiniz.
    - `GOOGLE_APPLICATION_CREDENTIALS`: Firebase servis hesabı JSON dosyasının yolu (dosyayı depo dışına koyun ve versiyon kontrolüne eklemeyin)
    - `FIREBASE_STORAGE_BUCKET`: Firebase Storage bucket adı (örn. `proje-id.appspot.com`)
 
+   Bu değişkenler ayarlanmazsa yüklenen dosyalar yerel olarak `static/uploads/` klasörüne kaydedilir.
+
 ## QR Kod Oluşturma
 
 QR kod oluşturmak için [qr-code-generator.com](https://www.qr-code-generator.com/)


### PR DESCRIPTION
## Summary
- support local file storage when Firebase storage isn't configured
- document local upload behavior and ignore uploaded files

## Testing
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_68ad8541e1648333a77e162e8c766e72