### PR TITLE
Ensure unique filenames for uploaded photos

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,9 @@ kullanabilirsiniz.
    - `GOOGLE_APPLICATION_CREDENTIALS`: Firebase servis hesabı JSON dosyasının yolu (dosyayı depo dışına koyun ve versiyon kontrolüne eklemeyin)
    - `FIREBASE_STORAGE_BUCKET`: Firebase Storage bucket adı (örn. `proje-id.appspot.com`)
 
-   Bu değişkenler ayarlanmazsa yüklenen dosyalar yerel olarak `static/uploads/` klasörüne kaydedilir.
+    Bu değişkenler ayarlanmazsa yüklenen dosyalar yerel olarak `static/uploads/` klasörüne kaydedilir.
+    Yüklenen her fotoğraf benzersiz bir adla kaydedilir; böylece aynı dosya adını kullanan farklı
+    yüklemeler önceki fotoğrafların üzerine yazılmaz.
 
 ## QR Kod Oluşturma
 

--- a/app.py
+++ b/app.py
@@ -9,6 +9,7 @@ from werkzeug.utils import secure_filename
 from io import BytesIO
 import logging
 import os
+import uuid
 
 import firebase_admin
 from firebase_admin import credentials, storage
@@ -63,11 +64,13 @@ def upload_file():
             return 'Dosya seçilmedi', 400
         if file and allowed_file(file.filename):
             filename = secure_filename(file.filename)
+            ext = os.path.splitext(filename)[1].lower()
+            unique_name = f"{uuid.uuid4().hex}{ext}"
             if bucket:
-                blob = bucket.blob(filename)
+                blob = bucket.blob(unique_name)
                 blob.upload_from_file(file, content_type=file.content_type)
             else:
-                file.save(os.path.join(UPLOAD_FOLDER, filename))
+                file.save(os.path.join(UPLOAD_FOLDER, unique_name))
             return render_template('success.html')
         else:
             return 'Geçersiz dosya türü', 400


### PR DESCRIPTION
## Summary
- Prevent uploaded files from overwriting each other by assigning a UUID-based filename
- Document that uploaded photos are stored with unique names

## Testing
- `python -m py_compile app.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b46b3ebaec83339b60d21a6014c207