### PR TITLE
Integrate Firebase JS SDK for client uploads

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,12 +30,16 @@ kullanabilirsiniz.
 
 4. Firebase Storage kullanmak için aşağıdaki ortam değişkenlerini ayarlayın:
 
-   - `GOOGLE_APPLICATION_CREDENTIALS`: Firebase servis hesabı JSON dosyasının yolu (dosyayı depo dışına koyun ve versiyon kontrolüne eklemeyin)
+   - `GOOGLE_APPLICATION_CREDENTIALS`: Firebase servis hesabı JSON dosyasının yolu (dosyayı depo dışına koyun ve versiyon kontrole eklemeyin)
    - `FIREBASE_STORAGE_BUCKET`: Firebase Storage bucket adı (örn. `proje-id.appspot.com`)
 
-    Bu değişkenler ayarlanmazsa yüklenen dosyalar yerel olarak `static/uploads/` klasörüne kaydedilir.
-    Yüklenen her fotoğraf benzersiz bir adla kaydedilir; böylece aynı dosya adını kullanan farklı
-    yüklemeler önceki fotoğrafların üzerine yazılmaz.
+   Bu değişkenler ayarlanmazsa yüklenen dosyalar yerel olarak `static/uploads/` klasörüne kaydedilir.
+   Yüklenen her fotoğraf benzersiz bir adla kaydedilir; böylece aynı dosya adını kullanan farklı
+   yüklemeler önceki fotoğrafların üzerine yazılmaz.
+
+5. Ziyaretçilerin fotoğrafları doğrudan Firebase Storage'a yükleyebilmesi için
+   `static/firebase-init.js` dosyasındaki `firebaseConfig` nesnesini kendi
+   Firebase projenize ait değerlerle güncelleyin.
 
 ## QR Kod Oluşturma
 

--- a/static/firebase-init.js
+++ b/static/firebase-init.js
@@ -1,0 +1,19 @@
+// Firebase configuration and initialization
+// Replace the placeholders below with your Firebase project configuration
+const firebaseConfig = {
+  apiKey: "YOUR_API_KEY",
+  authDomain: "YOUR_PROJECT_ID.firebaseapp.com",
+  projectId: "YOUR_PROJECT_ID",
+  storageBucket: "YOUR_PROJECT_ID.appspot.com",
+  messagingSenderId: "YOUR_MESSAGING_SENDER_ID",
+  appId: "YOUR_APP_ID"
+};
+
+// Initialize Firebase
+firebase.initializeApp(firebaseConfig);
+
+// Get a reference to the storage service
+const storage = firebase.storage();
+
+// Expose storage for other scripts
+window.storage = storage;

--- a/static/upload.js
+++ b/static/upload.js
@@ -1,0 +1,25 @@
+// Handle file uploads to Firebase Storage
+const form = document.getElementById('uploadForm');
+const fileInput = document.getElementById('fileInput');
+
+form.addEventListener('submit', function (e) {
+  e.preventDefault();
+  const file = fileInput.files[0];
+  if (!file) {
+    alert('Lütfen bir dosya seçin.');
+    return;
+  }
+
+  const uniqueName = Date.now() + '-' + file.name;
+  const storageRef = window.storage.ref(uniqueName);
+
+  storageRef.put(file)
+    .then(() => {
+      alert('Dosya başarıyla yüklendi!');
+      fileInput.value = '';
+    })
+    .catch((error) => {
+      console.error('Yükleme sırasında hata:', error);
+      alert('Yükleme sırasında hata: ' + error.message);
+    });
+});

--- a/templates/upload.html
+++ b/templates/upload.html
@@ -1,7 +1,11 @@
 {% extends 'base.html' %}
 {% block content %}
-<form class="upload-form" method="post" enctype="multipart/form-data">
-  <input type="file" name="file" accept="image/*" required>
+<form id="uploadForm" class="upload-form">
+  <input type="file" id="fileInput" accept="image/*" required>
   <button type="submit" class="btn">Yükle</button>
 </form>
+<script src="https://www.gstatic.com/firebasejs/8.10.1/firebase-app.js"></script>
+<script src="https://www.gstatic.com/firebasejs/8.10.1/firebase-storage.js"></script>
+<script src="{{ url_for('static', filename='firebase-init.js') }}"></script>
+<script src="{{ url_for('static', filename='upload.js') }}"></script>
 {% endblock %}


### PR DESCRIPTION
## Summary
- enable client-side photo uploads via Firebase Storage using JavaScript SDK
- initialize Firebase in a new `firebase-init.js` and expose storage
- handle uploads in `upload.js` with unique naming
- document updating Firebase config in README

## Testing
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_68b479e89da88333ac9969ed038a207c