### PR TITLE
Persist uploaded images with SQLite backend

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ __pycache__/
 uploads/
 static/uploads/
 *-firebase-adminsdk-*.json
+images.db

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,2 @@
 Flask==2.3.2
 Werkzeug==2.3.4
-firebase-admin==6.3.0

--- a/templates/gallery.html
+++ b/templates/gallery.html
@@ -4,8 +4,8 @@
 <div class="gallery-grid">
   {% for image in images %}
     <div>
-      <img src="{{ url_for('view_image', filename=image) }}" alt="{{ image }}">
-      <div><a href="{{ url_for('download_image', filename=image) }}">İndir</a></div>
+      <img src="{{ url_for('view_image', image_id=image.id) }}" alt="{{ image.filename }}">
+      <div><a href="{{ url_for('download_image', image_id=image.id) }}">İndir</a></div>
     </div>
   {% endfor %}
 </div>


### PR DESCRIPTION
## Summary
- Replace file/Firebase storage with a SQLite database to persist uploaded images
- Adjust gallery and download routes to serve images by id
- Clean up dependencies and ignore database file

## Testing
- `python -m py_compile app.py`
- `python - <<'PY'
from app import app, DATABASE
import sqlite3, os
from io import BytesIO

client = app.test_client()
# create a simple image file in memory (1x1 pixel GIF)
image_data = b'GIF89a\x01\x00\x01\x00\x80\x00\x00\xff\xff\xff\x00\x00\x00!\xf9\x04\x00\x00\x00\x00\x00,\x00\x00\x00\x00\x01\x00\x01\x00\x00\x02\x02D\x01\x00;'

resp = client.post('/upload', data={'file': (BytesIO(image_data), 'test.gif')}, content_type='multipart/form-data')
print('upload status', resp.status_code)

resp = client.get('/gallery')
print('gallery page length', len(resp.data))

# check DB entries
conn = sqlite3.connect(DATABASE)
cur = conn.execute('SELECT id, filename FROM images')
rows = cur.fetchall()
print('rows', rows)
conn.close()
PY`
- `python - <<'PY'
from app import app

client=app.test_client()
# assume image id 1
resp = client.get('/image/1')
print('view status', resp.status_code, 'length', len(resp.data))

resp = client.get('/download/1')
print('download status', resp.status_code, 'content-disposition', resp.headers.get('Content-Disposition'))
PY`


------
https://chatgpt.com/codex/tasks/task_e_68b489c528c88333a72af41b7b504276