### PR TITLE
Use writable temp dir for SQLite on Vercel

### DIFF
--- a/app.py
+++ b/app.py
@@ -14,7 +14,13 @@ ALLOWED_EXTENSIONS = {"png", "jpg", "jpeg", "gif"}
 
 app = Flask(__name__)
 
-DATABASE = os.path.join(os.path.dirname(__file__), "images.db")
+# Store the SQLite database in a writable directory. Vercel serverless functions
+# run in a read-only filesystem except for ``/tmp``. Default to that location
+# but allow overriding via the ``DATABASE_DIR`` environment variable for local
+# development or custom deployments.
+DATABASE_DIR = os.environ.get("DATABASE_DIR", "/tmp")
+os.makedirs(DATABASE_DIR, exist_ok=True)
+DATABASE = os.path.join(DATABASE_DIR, "images.db")
 
 
 def init_db():


### PR DESCRIPTION
## Summary
- Store SQLite database in `/tmp` so it runs on Vercel's read-only filesystem
- Allow overriding the directory with a `DATABASE_DIR` environment variable

## Testing
- `pip install -r requirements.txt`
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_68b491f1c2848333aeee822c6d0b6a4c