### PR TITLE
Store photos on filesystem

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 __pycache__/
-uploads/
-static/uploads/
+/uploads/
+static/uploads/*
+!static/uploads/.gitkeep
 *-firebase-adminsdk-*.json
 images.db

--- a/README.md
+++ b/README.md
@@ -28,14 +28,9 @@ galeri `http://<sunucu_adresi>:5000/gallery` adresinde yer alır. Örneğin, ken
 bilgisayarınızda test etmek için `http://localhost:5000/` adresini
 kullanabilirsiniz.
 
-4. Firebase Storage kullanmak için aşağıdaki ortam değişkenlerini ayarlayın:
-
-   - `GOOGLE_APPLICATION_CREDENTIALS`: Firebase servis hesabı JSON dosyasının yolu (dosyayı depo dışına koyun ve versiyon kontrolüne eklemeyin)
-   - `FIREBASE_STORAGE_BUCKET`: Firebase Storage bucket adı (örn. `proje-id.appspot.com`)
-
-    Bu değişkenler ayarlanmazsa yüklenen dosyalar yerel olarak `static/uploads/` klasörüne kaydedilir.
-    Yüklenen her fotoğraf benzersiz bir adla kaydedilir; böylece aynı dosya adını kullanan farklı
-    yüklemeler önceki fotoğrafların üzerine yazılmaz.
+Yüklenen dosyalar varsayılan olarak `static/uploads/` klasörüne kaydedilir.
+Her fotoğraf benzersiz bir adla saklanır; böylece aynı dosya adını kullanan
+farklı yüklemeler önceki fotoğrafların üzerine yazılmaz.
 
 ## QR Kod Oluşturma
 

--- a/templates/gallery.html
+++ b/templates/gallery.html
@@ -4,8 +4,8 @@
 <div class="gallery-grid">
   {% for image in images %}
     <div>
-      <img src="{{ url_for('view_image', image_id=image.id) }}" alt="{{ image.filename }}">
-      <div><a href="{{ url_for('download_image', image_id=image.id) }}">İndir</a></div>
+      <img src="{{ url_for('view_image', filename=image) }}" alt="{{ image }}">
+      <div><a href="{{ url_for('download_image', filename=image) }}">İndir</a></div>
     </div>
   {% endfor %}
 </div>


### PR DESCRIPTION
## Summary
- Save uploaded images to a writable uploads folder instead of SQLite
- Update gallery template and documentation for new file-based storage
- Allow tracking the uploads directory with a .gitkeep file

## Testing
- `python -m py_compile app.py`
- `python - <<'PY'
from app import app, UPLOAD_FOLDER
import io, os, glob

client = app.test_client()
for f in glob.glob(os.path.join(UPLOAD_FOLDER, '*')):
    os.remove(f)
resp = client.post('/upload', data={'file': (io.BytesIO(b'test data'), 'test.jpg')}, content_type='multipart/form-data')
print('status', resp.status_code)
print('files', os.listdir(UPLOAD_FOLDER))
PY`


------
https://chatgpt.com/codex/tasks/task_e_68b604b743248333ab8654edb8a1ff52