### PR TITLE
Improve server robustness and health check

### DIFF
--- a/app.py
+++ b/app.py
@@ -4,14 +4,21 @@ from flask import (
     render_template,
     send_file,
     abort,
+    jsonify,
 )
 from werkzeug.utils import secure_filename
+from werkzeug.exceptions import RequestEntityTooLarge
 import os
 import uuid
+import logging
 
 ALLOWED_EXTENSIONS = {"png", "jpg", "jpeg", "gif"}
 
 app = Flask(__name__)
+logging.basicConfig(level=logging.INFO)
+
+# Limit upload size to 16MB to avoid timeouts on large files
+app.config["MAX_CONTENT_LENGTH"] = 16 * 1024 * 1024
 
 # Determine a writable upload directory. Vercel provides only ``/tmp`` for
 # write access, so use that when the ``VERCEL`` env var is set; otherwise keep
@@ -28,27 +35,44 @@ def allowed_file(filename):
     return "." in filename and filename.rsplit(".", 1)[1].lower() in ALLOWED_EXTENSIONS
 
 
+@app.errorhandler(RequestEntityTooLarge)
+def handle_file_too_large(e):
+    """Return JSON response when the uploaded file exceeds the size limit."""
+    app.logger.warning("File too large: %s", e)
+    return jsonify({"error": "Dosya çok büyük"}), 413
+
+
 @app.route("/")
 def index():
     return render_template("index.html")
+
+
+@app.route("/status")
+def status():
+    """Simple endpoint for uptime checks"""
+    return jsonify({"status": "ok"})
 
 
 @app.route("/upload", methods=["GET", "POST"])
 def upload_file():
     if request.method == "POST":
         if "file" not in request.files:
-            return "Dosya bulunamadı", 400
+            return jsonify({"error": "Dosya bulunamadı"}), 400
         file = request.files["file"]
         if file.filename == "":
-            return "Dosya seçilmedi", 400
+            return jsonify({"error": "Dosya seçilmedi"}), 400
         if file and allowed_file(file.filename):
             filename = secure_filename(file.filename)
             ext = os.path.splitext(filename)[1].lower()
             unique_name = f"{uuid.uuid4().hex}{ext}"
-            file.save(os.path.join(UPLOAD_FOLDER, unique_name))
+            try:
+                file.save(os.path.join(UPLOAD_FOLDER, unique_name))
+            except OSError:
+                app.logger.exception("Dosya kaydedilirken hata oluştu")
+                return jsonify({"error": "Sunucu hatası"}), 500
             return render_template("success.html")
         else:
-            return "Geçersiz dosya türü", 400
+            return jsonify({"error": "Geçersiz dosya türü"}), 400
     return render_template("upload.html")
 
 


### PR DESCRIPTION
## Summary
- add JSON error responses and try/except handling when uploading
- limit upload size and configure logging
- expose `/status` endpoint for health checks
- return JSON response when uploads exceed 16MB

## Testing
- `python -m py_compile app.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b60806a6888333a9f5ecdbc159d92a