### PR TITLE
Add Firebase Storage upload logic

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,30 @@ Yüklenen dosyalar varsayılan olarak `static/uploads/` klasörüne kaydedilir.
 Her fotoğraf benzersiz bir adla saklanır; böylece aynı dosya adını kullanan
 farklı yüklemeler önceki fotoğrafların üzerine yazılmaz.
 
+## Firebase Storage Ayarları
+
+Web arayüzünden Firebase Storage'a yükleme yapabilmek için proje ayarlarını girmelisiniz. Bu bilgileri almak için:
+
+1. [Firebase Console](https://console.firebase.google.com/) üzerinden projenizi açın.
+2. Sol üstten **Project settings** (Proje ayarları) menüsüne gidin.
+3. **General** sekmesinde "Your apps" bölümünden web uygulamanızı seçin veya yeni bir web uygulaması ekleyin.
+4. Çıkan "Firebase SDK snippet" kısmından `apiKey`, `authDomain`, `projectId`, `storageBucket`, `messagingSenderId` ve `appId` değerlerini kopyalayın.
+
+Bu değerleri sunucunuzda ortam değişkeni olarak tanımlayın:
+
+```bash
+export FIREBASE_API_KEY="<apiKey>"
+export FIREBASE_AUTH_DOMAIN="<authDomain>"
+export FIREBASE_PROJECT_ID="<projectId>"
+export FIREBASE_STORAGE_BUCKET="<storageBucket>"
+export FIREBASE_MESSAGING_SENDER_ID="<messagingSenderId>"
+export FIREBASE_APP_ID="<appId>"
+```
+
+Uygulama bu değişkenleri kullanarak `templates/upload.html` içerisinde Firebase SDK'sını yapılandırır.
+
+Frontend üzerinden yapılan yüklemeler Firebase Storage içinde `uploads/` klasöründe benzersiz adlarla saklanır; böylece aynı ada sahip dosyalar çakışmaz.
+
 ## QR Kod Oluşturma
 
 QR kod oluşturmak için [qr-code-generator.com](https://www.qr-code-generator.com/)

--- a/app.py
+++ b/app.py
@@ -73,7 +73,15 @@ def upload_file():
             return render_template("success.html")
         else:
             return jsonify({"error": "Geçersiz dosya türü"}), 400
-    return render_template("upload.html")
+    firebase_config = {
+        "apiKey": os.environ.get("FIREBASE_API_KEY"),
+        "authDomain": os.environ.get("FIREBASE_AUTH_DOMAIN"),
+        "projectId": os.environ.get("FIREBASE_PROJECT_ID"),
+        "storageBucket": os.environ.get("FIREBASE_STORAGE_BUCKET"),
+        "messagingSenderId": os.environ.get("FIREBASE_MESSAGING_SENDER_ID"),
+        "appId": os.environ.get("FIREBASE_APP_ID"),
+    }
+    return render_template("upload.html", firebase_config=firebase_config)
 
 
 @app.route("/image/<filename>")

--- a/templates/upload.html
+++ b/templates/upload.html
@@ -1,7 +1,37 @@
 {% extends 'base.html' %}
 {% block content %}
-<form class="upload-form" method="post" enctype="multipart/form-data">
-  <input type="file" name="file" accept="image/*" required>
-  <button type="submit" class="btn">Yükle</button>
-</form>
-{% endblock %}
+<div class="upload-form">
+  <input type="file" id="photoInput" accept="image/*">
+  <button id="uploadButton" class="btn">Fotoğraf Yükle</button>
+</div>
+<script src="https://www.gstatic.com/firebasejs/9.0.0/firebase-app-compat.js"></script>
+<script src="https://www.gstatic.com/firebasejs/9.0.0/firebase-storage-compat.js"></script>
+<script>
+  // Firebase config values are injected from environment variables.
+  // See README.md for instructions on obtaining these from the Firebase console.
+  const firebaseConfig = {{ firebase_config | tojson }};
+  const app = firebase.initializeApp(firebaseConfig);
+  const storage = firebase.storage();
+
+  const fileInput = document.getElementById('photoInput');
+  const uploadButton = document.getElementById('uploadButton');
+
+    uploadButton.addEventListener('click', async () => {
+      const file = fileInput.files[0];
+      if (!file) {
+        alert('Lütfen önce bir dosya seçin.');
+        return;
+      }
+      try {
+        // Çakışmaları önlemek için dosya adına benzersiz bir önek ekle
+        const uniqueName = `${crypto.randomUUID()}-${file.name}`;
+        const storageRef = storage.ref(`uploads/${uniqueName}`);
+        await storageRef.put(file);
+        const downloadURL = await storageRef.getDownloadURL();
+        console.log('Dosya başarıyla yüklendi:', downloadURL);
+      } catch (error) {
+        console.error('Yükleme sırasında hata:', error);
+      }
+    });
+  </script>
+  {% endblock %}


### PR DESCRIPTION
## Summary
- Connect upload page to Firebase Storage using client-side SDK
- Load Firebase config from environment variables
- Document how to obtain Firebase keys and set them for the app
- Include messagingSenderId and appId in configuration and switch to Firebase compat scripts
- Generate unique filenames before uploading to Firebase Storage to avoid collisions

## Testing
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_68b61707c3b883339c445f0b412452d0